### PR TITLE
Limits for openreader

### DIFF
--- a/graphql-server/src/main.ts
+++ b/graphql-server/src/main.ts
@@ -14,6 +14,7 @@ runProgram(async () => {
     program.description(`GraphQL server for squids`)
     program.option('--no-squid-status', 'disable .squidStatus query')
     program.option('--max-request-size <kb>', 'max request size in kilobytes', nat, 256)
+    program.option('--max-root-fields <count>', 'max number of root fields in a query', nat)
     program.option('--max-response-size <nodes>', 'max response size measured in nodes', nat)
     program.option('--sql-statement-timeout <ms>', 'sql statement timeout in ms', nat)
     program.option('--subscriptions', 'enable gql subscriptions')
@@ -23,6 +24,7 @@ runProgram(async () => {
 
     let opts = program.parse().opts() as {
         maxRequestSize: number
+        maxRootFields?: number
         maxResponseSize?: number
         squidStatus?: boolean
         sqlStatementTimeout?: number

--- a/graphql-server/src/main.ts
+++ b/graphql-server/src/main.ts
@@ -1,9 +1,9 @@
-import {createLogger} from "@subsquid/logger"
-import {runProgram} from "@subsquid/util-internal"
-import {nat} from "@subsquid/util-internal-commander"
-import {waitForInterruption} from "@subsquid/util-internal-http-server"
-import {Command} from "commander"
-import {Server} from "./server"
+import {createLogger} from '@subsquid/logger'
+import {runProgram} from '@subsquid/util-internal'
+import {nat} from '@subsquid/util-internal-commander'
+import {waitForInterruption} from '@subsquid/util-internal-http-server'
+import {Command} from 'commander'
+import {Server} from './server'
 
 
 const LOG = createLogger('sqd:graphql-server')
@@ -14,25 +14,31 @@ runProgram(async () => {
     program.description(`GraphQL server for squids`)
     program.option('--no-squid-status', 'disable .squidStatus query')
     program.option('--max-request-size <kb>', 'max request size in kilobytes', nat, 256)
+    program.option('--max-response-size <nodes>', 'max response size measured in nodes', nat)
     program.option('--sql-statement-timeout <ms>', 'sql statement timeout in ms', nat)
     program.option('--subscriptions', 'enable gql subscriptions')
     program.option('--subscription-poll-interval <ms>', 'subscription poll interval in ms', nat, 5000)
+    program.option('--subscription-max-response-size <nodes>', 'max response size measured in nodes', nat)
     program.option('--subscription-sql-statement-timeout <ms>', 'sql statement timeout for polling queries', nat)
 
     let opts = program.parse().opts() as {
         maxRequestSize: number
+        maxResponseSize?: number
         squidStatus?: boolean
         sqlStatementTimeout?: number
         subscriptions?: boolean
         subscriptionPollInterval: number
         subscriptionSqlStatementTimeout?: number
+        subscriptionMaxResponseSize?: number
     }
 
-    let {maxRequestSize, ...rest} = opts
+    let {maxRequestSize, maxResponseSize, subscriptionMaxResponseSize, ...rest} = opts
 
     let server = await new Server({
         log: LOG,
         maxRequestSizeBytes: maxRequestSize * 1024,
+        maxResponseNodes: maxResponseSize,
+        subscriptionMaxResponseNodes: subscriptionMaxResponseSize,
         ...rest
     }).start()
 

--- a/graphql-server/src/server.ts
+++ b/graphql-server/src/server.ts
@@ -1,35 +1,38 @@
-import {mergeSchemas} from "@graphql-tools/schema"
-import {Logger} from "@subsquid/logger"
-import {Context} from "@subsquid/openreader/lib/context"
-import {PoolOpenreaderContext} from "@subsquid/openreader/lib/db"
-import {Dialect} from "@subsquid/openreader/lib/dialect"
-import type {Model} from "@subsquid/openreader/lib/model"
-import {SchemaBuilder} from "@subsquid/openreader/lib/opencrud/schema"
-import {addServerCleanup, Dispose, runApollo} from "@subsquid/openreader/lib/server"
-import {loadModel, resolveGraphqlSchema} from "@subsquid/openreader/lib/tools"
-import {def} from "@subsquid/util-internal"
-import {ListeningServer} from "@subsquid/util-internal-http-server"
-import {PluginDefinition} from "apollo-server-core"
-import assert from "assert"
-import {GraphQLInt, GraphQLObjectType, GraphQLSchema} from "graphql"
-import * as path from "path"
-import {Pool} from "pg"
-import * as process from "process"
-import type {DataSource} from "typeorm"
-import {createCheckPlugin, RequestCheckFunction} from "./check"
-import {loadCustomResolvers} from "./resolvers"
-import {TypeormOpenreaderContext} from "./typeorm"
+import {mergeSchemas} from '@graphql-tools/schema'
+import {Logger} from '@subsquid/logger'
+import {Context, OpenreaderContext} from '@subsquid/openreader/lib/context'
+import {PoolOpenreaderContext} from '@subsquid/openreader/lib/db'
+import {Dialect} from '@subsquid/openreader/lib/dialect'
+import type {Model} from '@subsquid/openreader/lib/model'
+import {SchemaBuilder} from '@subsquid/openreader/lib/opencrud/schema'
+import {addServerCleanup, Dispose, runApollo} from '@subsquid/openreader/lib/server'
+import {loadModel, resolveGraphqlSchema} from '@subsquid/openreader/lib/tools'
+import {ResponseSizeLimit} from '@subsquid/openreader/lib/util/limit'
+import {def} from '@subsquid/util-internal'
+import {ListeningServer} from '@subsquid/util-internal-http-server'
+import {PluginDefinition} from 'apollo-server-core'
+import assert from 'assert'
+import {GraphQLInt, GraphQLObjectType, GraphQLSchema} from 'graphql'
+import * as path from 'path'
+import {Pool} from 'pg'
+import * as process from 'process'
+import type {DataSource} from 'typeorm'
+import {createCheckPlugin, RequestCheckFunction} from './check'
+import {loadCustomResolvers} from './resolvers'
+import {TypeormOpenreaderContext} from './typeorm'
 
 
 export interface ServerOptions {
     dir?: string
     log?: Logger
     maxRequestSizeBytes?: number
+    maxResponseNodes?: number
     sqlStatementTimeout?: number
     squidStatus?: boolean
     subscriptions?: boolean
     subscriptionPollInterval?: number
     subscriptionSqlStatementTimeout?: number
+    subscriptionMaxResponseNodes?: number
 }
 
 
@@ -153,6 +156,7 @@ export class Server {
     @def
     private async context(): Promise<() => Context> {
         let dialect = this.dialect()
+        let createOpenreader: () => OpenreaderContext
         if (await this.customResolvers()) {
             let con = await this.createTypeormConnection({sqlStatementTimeout: this.options.sqlStatementTimeout})
             this.disposals.push(() => con.destroy())
@@ -163,10 +167,8 @@ export class Server {
                 })
                 this.disposals.push(() => subscriptionCon.destroy())
             }
-            return () => {
-                return {
-                    openreader: new TypeormOpenreaderContext(dialect, con, subscriptionCon, this.options.subscriptionPollInterval)
-                }
+            createOpenreader = () => {
+                return new TypeormOpenreaderContext(dialect, con, subscriptionCon, this.options.subscriptionPollInterval)
             }
         } else {
             let pool = await this.createPgPool({sqlStatementTimeout: this.options.sqlStatementTimeout})
@@ -178,11 +180,23 @@ export class Server {
                 })
                 this.disposals.push(() => subscriptionPool.end())
             }
-            return () => {
-                return {
-                    openreader: new PoolOpenreaderContext(dialect, pool, subscriptionPool, this.options.subscriptionPollInterval)
-                }
+            createOpenreader = () => {
+                return new PoolOpenreaderContext(dialect, pool, subscriptionPool, this.options.subscriptionPollInterval)
             }
+        }
+        return () => {
+            let openreader = createOpenreader()
+
+            if (this.options.maxResponseNodes) {
+                openreader.responseSizeLimit = new ResponseSizeLimit(this.options.maxResponseNodes)
+                openreader.subscriptionResponseSizeLimit = new ResponseSizeLimit(this.options.maxResponseNodes)
+            }
+
+            if (this.options.subscriptionMaxResponseNodes) {
+                openreader.subscriptionResponseSizeLimit = new ResponseSizeLimit(this.options.subscriptionMaxResponseNodes)
+            }
+
+            return {openreader}
         }
     }
 

--- a/graphql-server/src/server.ts
+++ b/graphql-server/src/server.ts
@@ -26,6 +26,7 @@ export interface ServerOptions {
     dir?: string
     log?: Logger
     maxRequestSizeBytes?: number
+    maxRootFields?: number
     maxResponseNodes?: number
     sqlStatementTimeout?: number
     squidStatus?: boolean
@@ -68,7 +69,8 @@ export class Server {
             log: this.options.log,
             subscriptions: this.options.subscriptions,
             graphiqlConsole: true,
-            maxRequestSizeBytes: this.options.maxRequestSizeBytes
+            maxRequestSizeBytes: this.options.maxRequestSizeBytes,
+            maxRootFields: this.options.maxRootFields
         })
     }
 

--- a/openreader/src/context.ts
+++ b/openreader/src/context.ts
@@ -1,5 +1,6 @@
-import {Dialect} from "./dialect"
-import {Query} from "./sql/query"
+import {Dialect} from './dialect'
+import {Query} from './sql/query'
+import {Limit} from './util/limit'
 
 
 export interface Context {
@@ -11,4 +12,6 @@ export interface OpenreaderContext {
     dialect: Dialect
     executeQuery<T>(query: Query<T>): Promise<T>
     subscription<T>(query: Query<T>): AsyncIterable<T>
+    responseSizeLimit?: Limit
+    subscriptionResponseSizeLimit?: Limit
 }

--- a/openreader/src/limit.size.ts
+++ b/openreader/src/limit.size.ts
@@ -1,4 +1,5 @@
 import {unexpectedCase} from '@subsquid/util-internal'
+import {Where} from './ir/args'
 import {RelayConnectionRequest} from './ir/connection'
 import {FieldRequest} from './ir/fields'
 import {Model} from './model'
@@ -36,7 +37,8 @@ function getFieldSize(model: Model, req: FieldRequest): number {
                 model,
                 req.type.entity,
                 req.children,
-                Math.min(req.args?.limit ?? Infinity, req.prop.cardinality ?? Infinity)
+                Math.min(req.args?.limit ?? Infinity, req.prop.cardinality ?? Infinity),
+                req.args?.where
             ) + 1
         default:
             throw unexpectedCase()
@@ -48,11 +50,13 @@ export function getEntityListSize(
     model: Model,
     entityName: string,
     fields: FieldRequest[],
-    limit?: number
+    limit?: number,
+    where?: Where
 ): number {
     let cardinality = Math.min(
         getEntityCardinality(model, entityName),
-        limit ?? Infinity
+        limit ?? Infinity,
+        getWhereCardinality(where)
     )
     if (Number.isFinite(cardinality)) {
         return cardinality * Math.max(getSize(model, fields), 1)
@@ -62,9 +66,49 @@ export function getEntityListSize(
 }
 
 
+function getWhereCardinality(where?: Where): number {
+    if (where == null) return Infinity
+    switch(where.op) {
+        case 'AND': {
+            let min = Infinity
+            for (let co of where.args) {
+                min = Math.min(min, getWhereCardinality(co))
+            }
+            return min
+        }
+        case 'OR': {
+            if (where.args.length == 0) return Infinity
+            let max = 0
+            for (let co of where.args) {
+                max = Math.max(max, getWhereCardinality(co))
+            }
+            return max
+        }
+        case 'eq':
+            if (where.field == 'id') {
+                return 1
+            } else {
+                return Infinity
+            }
+        case 'in':
+            if (where.field == 'id') {
+                return where.values.length
+            } else {
+                return Infinity
+            }
+        default:
+            return Infinity
+    }
+}
+
+
 export function getRelaySize(model: Model, entityName: string, req: RelayConnectionRequest): number {
     let total = 0
-    let limit = Math.min(getEntityCardinality(model, entityName), req.first ?? 100)
+    let limit = Math.min(
+        getEntityCardinality(model, entityName),
+        req.first ?? 100,
+        getWhereCardinality(req.where)
+    )
     if (req.edgeNode) {
         total += limit * Math.max(getSize(model, req.edgeNode), 1)
     }

--- a/openreader/src/limit.size.ts
+++ b/openreader/src/limit.size.ts
@@ -1,11 +1,14 @@
-import {unexpectedCase} from "@subsquid/util-internal"
-import {FieldRequest} from "./ir/fields"
+import {unexpectedCase} from '@subsquid/util-internal'
+import {RelayConnectionRequest} from './ir/connection'
+import {FieldRequest} from './ir/fields'
+import {Model} from './model'
+import {getEntity} from './model.tools'
 
 
-export function getSize(fields: FieldRequest[]): number {
+export function getSize(model: Model, fields: FieldRequest[]): number {
     let total = 0
     for (let req of fields) {
-        let size = getFieldSize(req)
+        let size = getFieldSize(model, req)
         if (Number.isFinite(size)) {
             total += size * req.aliases.length
         } else {
@@ -16,7 +19,7 @@ export function getSize(fields: FieldRequest[]): number {
 }
 
 
-function getFieldSize(req: FieldRequest): number {
+function getFieldSize(model: Model, req: FieldRequest): number {
     switch(req.kind) {
         case "scalar":
         case "list":
@@ -27,20 +30,57 @@ function getFieldSize(req: FieldRequest): number {
         case "fk":
         case "lookup":
         case "union":
-            return getSize(req.children) + 1
-        case "list-lookup": {
-            let limit = Math.min(req.args?.limit ?? Infinity, req.prop.cardinality ?? Infinity)
-            if (Number.isFinite(limit)) {
-                return limit * Math.max(getSize(req.children), 1)
-            } else {
-                return Infinity
-            }
-        }
+            return getSize(model, req.children) + 1
+        case "list-lookup":
+            return getEntityListSize(
+                model,
+                req.type.entity,
+                req.children,
+                Math.min(req.args?.limit ?? Infinity, req.prop.cardinality ?? Infinity)
+            ) + 1
         default:
             throw unexpectedCase()
     }
 }
 
 
+export function getEntityListSize(
+    model: Model,
+    entityName: string,
+    fields: FieldRequest[],
+    limit?: number
+): number {
+    let cardinality = Math.min(
+        getEntityCardinality(model, entityName),
+        limit ?? Infinity
+    )
+    if (Number.isFinite(cardinality)) {
+        return cardinality * Math.max(getSize(model, fields), 1)
+    } else {
+        return Infinity
+    }
+}
 
 
+export function getRelaySize(model: Model, entityName: string, req: RelayConnectionRequest): number {
+    let total = 0
+    let limit = Math.min(getEntityCardinality(model, entityName), req.first ?? 100)
+    if (req.edgeNode) {
+        total += limit * Math.max(getSize(model, req.edgeNode), 1)
+    }
+    if (req.edgeCursor) {
+        total += limit
+    }
+    if (req.pageInfo) {
+        total += 4
+    }
+    if (req.totalCount) {
+        total += 1
+    }
+    return total
+}
+
+
+function getEntityCardinality(model: Model, entityName: string): number {
+    return getEntity(model, entityName).cardinality ?? Infinity
+}

--- a/openreader/src/main.ts
+++ b/openreader/src/main.ts
@@ -26,6 +26,7 @@ GraphQL server for postgres-compatible databases
     )
     program.option('-p, --port <number>', 'port to listen on', nat, 3000)
     program.option('--max-request-size <kb>', 'max request size in kilobytes', nat, 256)
+    program.option('--max-root-fields <count>', 'max number of root fields in a query', nat)
     program.option('--max-response-size <nodes>', 'max response size measured in nodes', nat)
     program.option('--sql-statement-timeout <ms>', 'sql statement timeout in ms', nat)
     program.option('--subscriptions', 'enable gql subscriptions')
@@ -39,6 +40,7 @@ GraphQL server for postgres-compatible databases
         dbType: Dialect
         port: number
         maxRequestSize: number
+        maxRootFields?: number
         maxResponseSize?: number
         sqlStatementTimeout?: number
         subscriptions?: boolean
@@ -69,6 +71,7 @@ GraphQL server for postgres-compatible databases
         port: opts.port,
         log: LOG,
         maxRequestSizeBytes: opts.maxRequestSize * 1024,
+        maxRootFields: opts.maxRootFields,
         maxResponseNodes: opts.maxResponseSize,
         subscriptions: opts.subscriptions,
         subscriptionPollInterval: opts.subscriptionPollInterval,

--- a/openreader/src/main.ts
+++ b/openreader/src/main.ts
@@ -1,12 +1,12 @@
-import {createLogger} from "@subsquid/logger"
-import {runProgram} from "@subsquid/util-internal"
-import {nat, Url} from "@subsquid/util-internal-commander"
-import {waitForInterruption} from "@subsquid/util-internal-http-server"
-import {Command, Option} from "commander"
-import {Pool} from "pg"
-import {Dialect} from "./dialect"
-import {serve} from "./server"
-import {loadModel} from "./tools"
+import {createLogger} from '@subsquid/logger'
+import {runProgram} from '@subsquid/util-internal'
+import {nat, Url} from '@subsquid/util-internal-commander'
+import {waitForInterruption} from '@subsquid/util-internal-http-server'
+import {Command, Option} from 'commander'
+import {Pool} from 'pg'
+import {Dialect} from './dialect'
+import {serve} from './server'
+import {loadModel} from './tools'
 
 
 const LOG = createLogger('sqd:openreader')
@@ -26,10 +26,12 @@ GraphQL server for postgres-compatible databases
     )
     program.option('-p, --port <number>', 'port to listen on', nat, 3000)
     program.option('--max-request-size <kb>', 'max request size in kilobytes', nat, 256)
+    program.option('--max-response-size <nodes>', 'max response size measured in nodes', nat)
     program.option('--sql-statement-timeout <ms>', 'sql statement timeout in ms', nat)
     program.option('--subscriptions', 'enable gql subscriptions')
     program.option('--subscription-poll-interval <ms>', 'subscription poll interval in ms', nat, 1000)
     program.option('--subscription-sql-statement-timeout <ms>', 'sql statement timeout for polling queries', nat)
+    program.option('--subscription-max-response-size <nodes>', 'max response size measured in nodes', nat)
 
     let opts = program.parse().opts() as {
         schema: string
@@ -37,10 +39,12 @@ GraphQL server for postgres-compatible databases
         dbType: Dialect
         port: number
         maxRequestSize: number
+        maxResponseSize?: number
         sqlStatementTimeout?: number
         subscriptions?: boolean
         subscriptionPollInterval: number
         subscriptionSqlStatementTimeout?: number
+        subscriptionMaxResponseSize?: number
     }
 
     let model = loadModel(opts.schema)
@@ -65,9 +69,11 @@ GraphQL server for postgres-compatible databases
         port: opts.port,
         log: LOG,
         maxRequestSizeBytes: opts.maxRequestSize * 1024,
+        maxResponseNodes: opts.maxResponseSize,
         subscriptions: opts.subscriptions,
         subscriptionPollInterval: opts.subscriptionPollInterval,
-        subscriptionConnection
+        subscriptionConnection,
+        subscriptionMaxResponseNodes: opts.subscriptionMaxResponseSize
     })
 
     LOG.info(`listening on port ${server.port}`)

--- a/openreader/src/model.schema.ts
+++ b/openreader/src/model.schema.ts
@@ -77,11 +77,12 @@ function addEntityOrJsonObjectOrInterface(model: Model, type: GraphQLObjectType 
     let properties: Record<string, Prop> = {}
     let interfaces: string[] = []
     let indexes: Index[] = type instanceof GraphQLObjectType ? checkEntityIndexes(type) : []
+    let cardinality = checkEntityCardinality(type)
     let description = type.description || undefined
 
     switch(kind) {
         case 'entity':
-            model[type.name] = {kind, properties, description, interfaces, indexes}
+            model[type.name] = {kind, properties, description, interfaces, indexes, ...cardinality}
             break
         case 'object':
             model[type.name] = {kind, properties, description, interfaces}
@@ -467,10 +468,29 @@ function checkDerivedFrom(type: GraphQLNamedType, f: GraphQLField<any, any>): {f
 }
 
 
+function checkEntityCardinality(type: GraphQLObjectType | GraphQLInterfaceType): {cardinality?: number} {
+    let directives = type.astNode?.directives?.filter(d => d.name.value == 'cardinality') || []
+    if (directives.length > 0 && !isEntityType(type)) {
+        throw new SchemaError(`@cardinality directive can be only applied to entities, but were applied to ${type.name}`)
+    }
+    if (directives.length > 1) throw new SchemaError(
+        `Multiple @cardinality directives where applied to ${type.name}`
+    )
+    if (directives.length == 0) return {}
+    let arg = assertNotNull(directives[0].arguments?.find(arg => arg.name.value == 'value'))
+    assert(arg.value.kind == 'IntValue')
+    let cardinality = parseInt(arg.value.value, 10)
+    if (cardinality < 0) throw new SchemaError(
+        `Incorrect @cardinality where applied to ${type.name}. Cardinality value must be positive.`
+    )
+    return {cardinality}
+}
+
+
 function checkCardinalityLimitDirective(type: GraphQLNamedType, f: GraphQLField<any, any>): {cardinality?: number} {
     let directives = f.astNode?.directives?.filter(d => d.name.value == 'cardinality') || []
     if (directives.length > 1) throw new SchemaError(
-        `Multiple @cardinality where applied to ${type.name}.${f.name}`
+        `Multiple @cardinality directives where applied to ${type.name}.${f.name}`
     )
     if (directives.length == 0) return {}
     let arg = assertNotNull(directives[0].arguments?.find(arg => arg.name.value == 'value'))
@@ -486,7 +506,7 @@ function checkCardinalityLimitDirective(type: GraphQLNamedType, f: GraphQLField<
 function checkByteWeightDirective(type: GraphQLNamedType, f: GraphQLField<any, any>): {byteWeight?: number} {
     let directives = f.astNode?.directives?.filter(d => d.name.value == 'byteWeight') || []
     if (directives.length > 1) throw new SchemaError(
-        `Multiple @byteWeight where applied to ${type.name}.${f.name}`
+        `Multiple @byteWeight directives where applied to ${type.name}.${f.name}`
     )
     if (directives.length == 0) return {}
     let arg = assertNotNull(directives[0].arguments?.find(arg => arg.name.value == 'value'))

--- a/openreader/src/model.schema.ts
+++ b/openreader/src/model.schema.ts
@@ -29,7 +29,7 @@ const baseSchema = buildASTSchema(parse(`
     directive @unique on FIELD_DEFINITION
     directive @index(fields: [String!] unique: Boolean) on OBJECT | FIELD_DEFINITION
     directive @fulltext(query: String!) on FIELD_DEFINITION
-    directive @cardinality(value: Int!) on FIELD_DEFINITION
+    directive @cardinality(value: Int!) on OBJECT | FIELD_DEFINITION
     directive @byteWeight(value: Float!) on FIELD_DEFINITION
     directive @variant on OBJECT # legacy
     directive @jsonField on OBJECT # legacy

--- a/openreader/src/model.ts
+++ b/openreader/src/model.ts
@@ -9,6 +9,7 @@ export interface Entity extends TypeMeta {
     properties: Record<Name, Prop>
     interfaces?: Name[]
     indexes?: Index[]
+    cardinality?: number
 }
 
 

--- a/openreader/src/opencrud/schema.ts
+++ b/openreader/src/opencrud/schema.ts
@@ -29,11 +29,13 @@ import {
 } from "graphql/type/definition"
 import {Context} from "../context"
 import {decodeRelayConnectionCursor, RelayConnectionRequest} from "../ir/connection"
+import {getEntityListSize, getRelaySize, getSize} from '../limit.size'
 import {Entity, Interface, JsonObject, Model, Prop} from "../model"
 import {getObject, getUnionProps} from "../model.tools"
 import {customScalars} from "../scalars"
 import {EntityByIdQuery, EntityConnectionQuery, EntityCountQuery, EntityListQuery, Query} from "../sql/query"
 import {Subscription} from "../subscription"
+import {Limit} from '../util/limit'
 import {getResolveTree, getTreeRequest, hasTreeRequest, simplifyResolveTree} from "../util/resolve-tree"
 import {ensureArray, identity} from "../util/util"
 import {getOrderByMapping, parseOrderBy} from "./orderBy"
@@ -409,10 +411,11 @@ export class SchemaBuilder {
         let outputType = new GraphQLList(new GraphQLNonNull(this.get(entityName)))
         let argsType = this.entityListArguments(entityName)
 
-        function createQuery(context: Context, info: GraphQLResolveInfo) {
+        function createQuery(context: Context, info: GraphQLResolveInfo, limit?: Limit) {
             let tree = getResolveTree(info)
             let fields = parseResolveTree(model, entityName, info.schema, tree)
             let args = parseEntityListArguments(model, entityName, tree.args)
+            limit?.check(() => getEntityListSize(model, entityName, fields, args.limit) + 1)
             return new EntityListQuery(
                 model,
                 context.openreader.dialect,
@@ -426,7 +429,7 @@ export class SchemaBuilder {
             type: outputType,
             args: argsType,
             resolve(source, args, context, info) {
-                let q = createQuery(context, info)
+                let q = createQuery(context, info, context.openreader.responseSizeLimit)
                 return context.openreader.executeQuery(q)
             }
         }
@@ -436,7 +439,7 @@ export class SchemaBuilder {
             args: argsType,
             resolve: identity,
             subscribe(source, args, context, info) {
-                let q = createQuery(context, info)
+                let q = createQuery(context, info, context.openreader.subscriptionResponseSizeLimit)
                 return context.openreader.subscription(q)
             }
         }
@@ -449,9 +452,10 @@ export class SchemaBuilder {
             id: {type: new GraphQLNonNull(GraphQLString)}
         }
 
-        function createQuery(context: Context, info: GraphQLResolveInfo) {
+        function createQuery(context: Context, info: GraphQLResolveInfo, limit?: Limit) {
             let tree = getResolveTree(info)
             let fields = parseResolveTree(model, entityName, info.schema, tree)
+            limit?.check(() => getSize(model, fields) + 1)
             return new EntityByIdQuery(
                 model,
                 context.openreader.dialect,
@@ -465,7 +469,7 @@ export class SchemaBuilder {
             type: this.get(entityName),
             args: argsType,
             async resolve(source, args, context, info) {
-                let q = createQuery(context, info)
+                let q = createQuery(context, info, context.openreader.responseSizeLimit)
                 return context.openreader.executeQuery(q)
             }
         }
@@ -475,7 +479,7 @@ export class SchemaBuilder {
             args: argsType,
             resolve: identity,
             subscribe(source, args, context, info) {
-                let q = createQuery(context, info)
+                let q = createQuery(context, info, context.openreader.subscriptionResponseSizeLimit)
                 return context.openreader.subscription(q)
             }
         }
@@ -493,6 +497,7 @@ export class SchemaBuilder {
             async resolve(source, args, context, info) {
                 let tree = getResolveTree(info)
                 let fields = parseResolveTree(model, entityName, info.schema, tree)
+                context.openreader.responseSizeLimit?.check(() => getSize(model, fields) + 1)
                 let query = new EntityListQuery(
                     model,
                     context.openreader.dialect,
@@ -576,6 +581,8 @@ export class SchemaBuilder {
                         req.edgeNode = parseResolveTree(model, entityName, info.schema, nodeTree)
                     }
                 }
+
+                context.openreader.responseSizeLimit?.check(() => getRelaySize(model, entityName, req) + 1)
 
                 let result = await context.openreader.executeQuery(new EntityConnectionQuery(
                     model,

--- a/openreader/src/opencrud/schema.ts
+++ b/openreader/src/opencrud/schema.ts
@@ -415,7 +415,7 @@ export class SchemaBuilder {
             let tree = getResolveTree(info)
             let fields = parseResolveTree(model, entityName, info.schema, tree)
             let args = parseEntityListArguments(model, entityName, tree.args)
-            limit?.check(() => getEntityListSize(model, entityName, fields, args.limit) + 1)
+            limit?.check(() => getEntityListSize(model, entityName, fields, args.limit, args.where) + 1)
             return new EntityListQuery(
                 model,
                 context.openreader.dialect,

--- a/openreader/src/test/limits.test.ts
+++ b/openreader/src/test/limits.test.ts
@@ -46,7 +46,8 @@ describe('response size limits', function() {
             name: String @byteWeight(value: 10.0)
         }
     `, {
-        maxResponseNodes: 50
+        maxResponseNodes: 50,
+        maxRootFields: 3
     })
 
     it('unlimited requests fail', async function() {
@@ -62,7 +63,7 @@ describe('response size limits', function() {
                 order1s: null
             },
             errors: [
-                expect.objectContaining({message: 'response size limit exceeded', path: ['order1s']})
+                expect.objectContaining({message: 'response might exceed the size limit', path: ['order1s']})
             ]
         })
     })
@@ -119,7 +120,7 @@ describe('response size limits', function() {
             },
             errors: [
                 expect.objectContaining({
-                    message: 'response size limit exceeded',
+                    message: 'response might exceed the size limit',
                     path: ['order3s']
                 })
             ]
@@ -132,6 +133,23 @@ describe('response size limits', function() {
             }
         `, {
             order3s: []
+        })
+    })
+
+    it('root query fields limit', async function() {
+        return client.errorTest(`
+            query {
+                a: order1ById(id: "1") { id }
+                b: order1ById(id: "1") { id }
+                c: order1ById(id: "1") { id }
+                d: order1ById(id: "1") { id }
+            }
+        `, {
+            errors: [
+                expect.objectContaining({
+                    message: 'only 3 root query fields allowed, but got 4'
+                })
+            ]
         })
     })
 })

--- a/openreader/src/test/limits.test.ts
+++ b/openreader/src/test/limits.test.ts
@@ -1,0 +1,86 @@
+import {useDatabase, useServer} from './setup'
+
+
+describe('response size limits', function() {
+    useDatabase([
+        `create table "order1" (id text primary key)`,
+        `create table item1 (id text primary key, order_id text, name text)`,
+        `create table "order2" (id text primary key)`,
+        `create table item2 (id text primary key, order_id text, name text)`,
+        `create table "order3" (id text primary key)`,
+        `create table item3 (id text primary key, order_id text, name text)`,
+    ])
+
+    const client = useServer(`
+        type Order1 @entity {
+            id: ID!
+            items: [Item1!]! @derivedFrom(field: "order")
+        }
+        
+        type Item1 @entity {
+            id: ID!
+            order: Order1!
+            name: String
+        }
+        
+        type Order2 @entity @cardinality(value: 10) {
+            id: ID!
+            items: [Item2!]! @derivedFrom(field: "order")
+        }
+        
+        type Item2 @entity {
+            id: ID!
+            order: Order2!
+            name: String
+        }
+        
+        type Order3 @entity {
+            id: ID!
+            items: [Item3!]! @derivedFrom(field: "order") @cardinality(value: 10)
+        }
+        
+        type Item3 @entity {
+            id: ID!
+            order: Order3!
+            name: String @byteWeight(value: 10.0)
+        }
+    `, {
+        maxResponseNodes: 50
+    })
+
+    it('unlimited requests fail', async function() {
+        let result = await client.query(`
+            query {
+                order1s {
+                    id
+                }
+            }
+        `)
+    })
+
+    it('limited requests work', function() {
+        return client.test(`
+            query {
+                order1s(limit: 10) {
+                    items(limit: 2) {
+                        id
+                    }
+                }
+            }
+        `, {
+            order1s: []
+        })
+    })
+
+    it('item cardinalities are respected', function() {
+        return client.test(`
+            query {
+                order3s(limit: 1) {
+                    items { id }
+                }
+            }
+        `, {
+            order3s: []
+        })
+    })
+})

--- a/openreader/src/test/limits.test.ts
+++ b/openreader/src/test/limits.test.ts
@@ -136,6 +136,18 @@ describe('response size limits', function() {
         })
     })
 
+    it('id_in conditions are understood', function() {
+        return client.test(`
+            query {
+                order1s(where: {id_in: ["1", "2", "3"]}) {
+                    id
+                }
+            }
+        `, {
+            order1s: []
+        })
+    })
+
     it('root query fields limit', async function() {
         return client.errorTest(`
             query {

--- a/openreader/src/test/limits.test.ts
+++ b/openreader/src/test/limits.test.ts
@@ -62,7 +62,7 @@ describe('response size limits', function() {
                 order1s: null
             },
             errors: [
-                expect.objectContaining({message: 'requested data size limit exceeded', path: ['order1s']})
+                expect.objectContaining({message: 'response size limit exceeded', path: ['order1s']})
             ]
         })
     })
@@ -119,7 +119,7 @@ describe('response size limits', function() {
             },
             errors: [
                 expect.objectContaining({
-                    message: 'requested data size limit exceeded',
+                    message: 'response size limit exceeded',
                     path: ['order3s']
                 })
             ]

--- a/openreader/src/test/setup.ts
+++ b/openreader/src/test/setup.ts
@@ -71,6 +71,7 @@ export function useServer(schema: string, options?: Partial<ServerOptions>): Cli
             dialect: isCockroach() ? 'cockroach' : 'postgres',
             subscriptions: true,
             subscriptionPollInterval: 500,
+            maxRootFields: 10,
             ...options
         })
         client.endpoint = `http://localhost:${info.port}/graphql`

--- a/openreader/src/test/setup.ts
+++ b/openreader/src/test/setup.ts
@@ -4,7 +4,7 @@ import {Client} from "gql-test-client"
 import {parse} from "graphql"
 import {Client as PgClient, ClientBase, Pool} from "pg"
 import {buildModel, buildSchema} from "../model.schema"
-import {serve} from "../server"
+import {serve, ServerOptions} from '../server'
 
 
 export function isCockroach(): boolean {
@@ -59,7 +59,7 @@ export function useDatabase(sql: string[]): void {
 }
 
 
-export function useServer(schema: string): Client {
+export function useServer(schema: string, options?: Partial<ServerOptions>): Client {
     let client = new Client('not defined')
     let db = new Pool(db_config)
     let info: ListeningServer | undefined
@@ -69,7 +69,9 @@ export function useServer(schema: string): Client {
             model: buildModel(buildSchema(parse(schema))),
             port: 0,
             dialect: isCockroach() ? 'cockroach' : 'postgres',
-            subscriptions: true
+            subscriptions: true,
+            subscriptionPollInterval: 500,
+            ...options
         })
         client.endpoint = `http://localhost:${info.port}/graphql`
     })

--- a/openreader/src/util/execute.ts
+++ b/openreader/src/util/execute.ts
@@ -1,0 +1,53 @@
+import {getOperationRootType, GraphQLError} from 'graphql'
+import {ExecutionResult} from 'graphql-ws'
+import {
+    assertValidExecutionArguments,
+    buildExecutionContext,
+    collectFields,
+    execute as graphqlExecute,
+    ExecutionArgs,
+    ExecutionContext
+} from 'graphql/execution/execute'
+import {PromiseOrValue} from 'graphql/jsutils/PromiseOrValue'
+
+
+export function executeWithLimit(maxQueries: number, args: ExecutionArgs): PromiseOrValue<ExecutionResult> {
+    assertValidExecutionArguments(args.schema, args.document, args.variableValues)
+
+    let xtx = buildExecutionContext(
+        args.schema,
+        args.document,
+        args.rootValue,
+        args.contextValue,
+        args.variableValues,
+        args.operationName,
+        args.fieldResolver,
+        args.typeResolver
+    )
+
+    if (Array.isArray(xtx)) {
+        return {errors: xtx}
+    }
+
+    let etx = xtx as ExecutionContext
+    if (etx.operation.operation == 'query') {
+        let query = getOperationRootType(etx.schema, etx.operation)
+        let fields = collectFields(
+            etx,
+            query,
+            etx.operation.selectionSet,
+            Object.create(null),
+            Object.create(null)
+        )
+        let fieldsCount = Object.keys(fields).length
+        if (fieldsCount > maxQueries) {
+            return {
+                errors: [
+                    new GraphQLError(`only ${maxQueries} root query fields allowed, but got ${fieldsCount}`)
+                ]
+            }
+        }
+    }
+
+    return graphqlExecute(args)
+}

--- a/openreader/src/util/limit.ts
+++ b/openreader/src/util/limit.ts
@@ -1,5 +1,5 @@
-import {UserInputError} from 'apollo-server-core'
 import assert from 'assert'
+import {GraphQLError} from 'graphql'
 
 
 export class Limit {
@@ -23,7 +23,7 @@ export class Limit {
 }
 
 
-const SIZE_LIMIT = new UserInputError('response size limit exceeded')
+const SIZE_LIMIT = new GraphQLError('response might exceed the size limit')
 SIZE_LIMIT.stack = undefined
 
 

--- a/openreader/src/util/limit.ts
+++ b/openreader/src/util/limit.ts
@@ -1,0 +1,33 @@
+import assert from 'assert'
+
+
+export class Limit {
+    private err?: Error
+
+    constructor(private name: string, private value: number) {
+        assert(this.value > 0)
+    }
+
+    get left(): number {
+        return this.value
+    }
+
+    check(cb: (left: number) => number): void {
+        if (this.err) throw this.err
+        let left = this.value - cb(this.value)
+        if (left < 0) {
+            this.value = 0
+            this.err = new Error(`${this.name} limit exceeded`)
+            throw this.err
+        } else {
+            this.value = left
+        }
+    }
+}
+
+
+export class ResponseSizeLimit extends Limit {
+    constructor(maxNodes: number) {
+        super('requested data size', maxNodes)
+    }
+}

--- a/substrate-explorer/schema.graphql
+++ b/substrate-explorer/schema.graphql
@@ -1,10 +1,10 @@
-type Metadata @entity {
+type Metadata @entity @cardinality(value: 100) {
     id: ID!
     specName: String!
     specVersion: Int
     blockHeight: Int!
     blockHash: String!
-    hex: String!
+    hex: String! @byteWeight(value: 1000.0)
 }
 
 type Block @entity {
@@ -17,9 +17,9 @@ type Block @entity {
     timestamp: BigInt!
     spec: Metadata!
     validator: String
-    events: [Event!]! @derivedFrom(field: "block")
-    calls: [Call!]! @derivedFrom(field: "block")
-    extrinsics: [Extrinsic!]! @derivedFrom(field: "block")
+    events: [Event!]! @derivedFrom(field: "block") @cardinality(value: 1000)
+    calls: [Call!]! @derivedFrom(field: "block") @cardinality(value: 1000)
+    extrinsics: [Extrinsic!]! @derivedFrom(field: "block") @cardinality(value: 1000)
 }
 
 type Call @entity {
@@ -31,7 +31,7 @@ type Call @entity {
     error: JSON
     origin: JSON
     name: String!
-    args: JSON
+    args: JSON @byteWeight(value: 5.0)
     pos: Int!
 }
 
@@ -43,7 +43,7 @@ type Event @entity {
     extrinsic: Extrinsic
     call: Call
     name: String!
-    args: JSON
+    args: JSON @byteWeight(value: 5.0)
     pos: Int!
 }
 
@@ -60,5 +60,5 @@ type Extrinsic @entity {
     tip: Int
     hash: String!
     pos: Int!
-    calls: [Call!] @derivedFrom(field: "extrinsic")
+    calls: [Call!] @derivedFrom(field: "extrinsic") @cardinality(value: 5)
 }

--- a/substrate-explorer/src/main.ts
+++ b/substrate-explorer/src/main.ts
@@ -1,12 +1,12 @@
-import {createLogger} from "@subsquid/logger"
-import {Dialect} from "@subsquid/openreader/lib/dialect"
-import {serve} from "@subsquid/openreader/lib/server"
-import {loadModel} from "@subsquid/openreader/lib/tools"
-import {ConnectionOptions, createConnectionOptions} from "@subsquid/typeorm-config/lib/connectionOptions"
-import {runProgram} from "@subsquid/util-internal"
-import {waitForInterruption} from "@subsquid/util-internal-http-server"
-import * as path from "path"
-import {Pool} from "pg"
+import {createLogger} from '@subsquid/logger'
+import {Dialect} from '@subsquid/openreader/lib/dialect'
+import {serve} from '@subsquid/openreader/lib/server'
+import {loadModel} from '@subsquid/openreader/lib/tools'
+import {ConnectionOptions, createConnectionOptions} from '@subsquid/typeorm-config/lib/connectionOptions'
+import {runProgram} from '@subsquid/util-internal'
+import {waitForInterruption} from '@subsquid/util-internal-http-server'
+import * as path from 'path'
+import {Pool} from 'pg'
 
 
 const log = createLogger('sqd:substrate-explorer')
@@ -58,7 +58,9 @@ runProgram(async () => {
         port: 3000,
         graphiqlConsole: true,
         log,
-        maxRequestSizeBytes: 64 * 1024
+        maxRequestSizeBytes: 64 * 1024,
+        maxRootFields: envNat('GQL_MAX_ROOT_FIELDS'),
+        maxResponseNodes: envNat('GQL_MAX_RESPONSE_NODES')
     })
 
     log.info(`listening on port ${server.port}`)
@@ -74,4 +76,13 @@ function createConnectionUrl(options: ConnectionOptions): string {
     url.username = options.username
     url.pathname = options.database
     return url.toString()
+}
+
+
+function envNat(name: string): number | undefined {
+    let env = process.env[name]
+    if (!env) return undefined
+    let val = parseInt(env, 10)
+    if (Number.isSafeInteger(val) && val >= 0) return val
+    throw new Error(`Invalid env variable ${name}: ${env}. Expected positive integer`)
 }


### PR DESCRIPTION
This PR adds 2 new options to `graphql-server` and `openreader`.

* `--max-response-size <nodes>` - maximum number of JSON nodes in GQL response
* `--max-root-fields <count>` - maximum number of top level fields in a query

The reason for 2 options for basically the same kind of limit is due to our current implementation details. Each access to a top level field implies database request. Hence, queries

```gql
query {
   i1: itemById(id: "1") { id }
   # ... 
   i100: itemById(id: "100") { id }
}
```

and 

```gql
query {
   items(limit: 100) {
      id
   }
}
```

being similar in size, have completely different complexities (not regulated by other means).

There are also 2 new schema directives, that help with response size estimation:

* `@cardinality(value: Int!)` - applicable to entities and list relations
* `@byteWeight(value: Float!)` - applicable to scalars and typed JSON fields on entities

Have a look at `substrate-explorer` to see example usage and to play with queries.