### PR TITLE
Add `Promise.race` to avoid ROLLBACK query getting stuck

### DIFF
--- a/substrate-ingest/src/sink.ts
+++ b/substrate-ingest/src/sink.ts
@@ -287,7 +287,10 @@ export class PostgresSink implements Sink {
             await this.db.query('COMMIT')
             return result
         } catch(e: any) {
-            await this.db.query('ROLLBACK').catch(() => {})
+            await Promise.race([
+                this.db.query('ROLLBACK').catch(() => {}),
+                new Promise((resolve) => setTimeout(resolve, 5000))
+            ])
             throw e
         }
     }


### PR DESCRIPTION
Closes #109 