### PR TITLE
retrieve validator from indexer gateway

### DIFF
--- a/substrate-processor/src/ingest.ts
+++ b/substrate-processor/src/ingest.ts
@@ -236,6 +236,7 @@ export class Ingest<R extends BatchRequest> {
                     q.line('specId')
                     q.line('stateRoot')
                     q.line('extrinsicsRoot')
+                    q.line('validator')
                 })
                 q.line('events')
                 q.line('calls')

--- a/substrate-processor/src/ingest.ts
+++ b/substrate-processor/src/ingest.ts
@@ -391,10 +391,10 @@ function tryMapGatewayBlock(block: gw.BatchBlock): BlockData {
 
     items.sort((a, b) => getPos(a) - getPos(b))
 
-    let {timestamp, ...hdr} = block.header
+    let {timestamp, validator, ...hdr} = block.header
 
     return {
-        header: {...hdr, timestamp: new Date(timestamp).valueOf()},
+        header: {...hdr, timestamp: new Date(timestamp).valueOf(), validator: validator ?? undefined},
         items: items
     }
 }

--- a/substrate-processor/src/interfaces/gateway.ts
+++ b/substrate-processor/src/interfaces/gateway.ts
@@ -55,7 +55,7 @@ export interface GearUserMessageSentRequest {
 
 
 export interface BatchBlock {
-    header: Omit<SubstrateBlock, 'timestamp'> & {timestamp: string}
+    header: Omit<SubstrateBlock, 'timestamp' | 'validator'> & {timestamp: string} & {validator: string | null}
     events: Event[]
     calls: Call[]
     extrinsics: Extrinsic[]


### PR DESCRIPTION
Adds `validator` to the gateway query and passes though the value to the handlers.