### PR TITLE
Add TypeOrm Subscribers

### DIFF
--- a/util/typeorm-config/src/config.ts
+++ b/util/typeorm-config/src/config.ts
@@ -17,11 +17,13 @@ export function createOrmConfig(options?: OrmOptions): OrmConfig {
     let dir = path.resolve(options?.projectDir || process.cwd())
     let model = resolveModel(path.join(dir, 'lib/model'))
     let migrationsDir = path.join(dir, MIGRATIONS_DIR)
+    let subscribersDir = path.join(dir, 'lib/model-subscriptions')
     return {
         type: 'postgres',
         namingStrategy: new SnakeNamingStrategy(),
         entities: [model],
         migrations: [migrationsDir + '/*.js'],
+        subscribers: [subscribersDir + '/*.js'],
         ...createConnectionOptions()
     }
 }


### PR DESCRIPTION
Hey Guys! We need to listen to model changes, to send notifications to another service, though this could be implemented in the mapper I feel doing this way is a little cleaner.