### PR TITLE
Fix substrate-explorer fee and tip schema to prevent errors when returning BigInts

### DIFF
--- a/common/changes/@subsquid/substrate-explorer/fix-fees-bigint_2022-11-16-11-57.json
+++ b/common/changes/@subsquid/substrate-explorer/fix-fees-bigint_2022-11-16-11-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@subsquid/substrate-explorer",
+      "comment": "Change extrinsic fee and tip GraphQL schema to BigInt",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@subsquid/substrate-explorer"
+}

--- a/substrate-explorer/schema.graphql
+++ b/substrate-explorer/schema.graphql
@@ -56,8 +56,8 @@ type Extrinsic @entity {
     success: Boolean!
     error: JSON
     call: Call!
-    fee: Int
-    tip: Int
+    fee: BigInt
+    tip: BigInt
     hash: String!
     pos: Int!
     calls: [Call!] @derivedFrom(field: "extrinsic") @cardinality(value: 5)


### PR DESCRIPTION
This PR fixes substrate-explorer GraphQL errors when it tries to convert big numeric values of `fee` and `tip` from DB into an integer.

This fixes error we've encountered when fetching extrinsics:
`Error: Int cannot represent non 32-bit signed integer value: \"4847399506\"",`
![image](https://user-images.githubusercontent.com/7070520/202175588-cba756c2-1de7-495c-8e12-f93341f77ab7.png)
